### PR TITLE
Add a sticky container for a playlist name and button

### DIFF
--- a/src/components/TrackPage.css
+++ b/src/components/TrackPage.css
@@ -1,0 +1,19 @@
+.stickyContainer {
+  position: sticky;
+  top: 0;
+  background-color: rgba(255, 255, 255, 0.5);
+  padding: 10px;
+  margin-top: 20px;
+}
+
+.addButton {
+  text-align: "center";
+  padding-top: 10px;
+  display: inline-block;
+  margin-left: 20px;
+  margin-bottom: 20px;
+}
+
+.playlistTitle {
+  display: inline-block;
+}

--- a/src/components/Tracks.js
+++ b/src/components/Tracks.js
@@ -23,7 +23,6 @@ class Tracks extends Component {
         <div>
           {" "}
           <div className="tableCaptionContainer">
-            <h1 className="caption">{this.props.title}</h1>
           </div>
           <div className="container">
             <table className="table">

--- a/src/components/TracksPage.js
+++ b/src/components/TracksPage.js
@@ -1,55 +1,70 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { getPlaylistTracks } from '../redux/actions/thunk';
-import Tracks from './Tracks';
-import { Link } from 'react-router-dom';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getPlaylistTracks } from "../redux/actions/thunk";
+import Tracks from "./Tracks";
+import { Link } from "react-router-dom";
 import * as spotify from "../SpotifyFunctions.js";
-import SearchPage from './SearchPage';
-import { Button } from 'reactstrap';
+import SearchPage from "./SearchPage";
+import { Button } from "reactstrap";
+import "./TrackPage.css";
 
-class TracksPage extends Component  {
+class TracksPage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      searchShowing: false,
+    };
+    this.toggleSearch = this.toggleSearch.bind(this);
+  }
 
-    constructor() {
-        super();
-        this.state = {
-            searchShowing: false
-        }
-        this.toggleSearch = this.toggleSearch.bind(this);
+  toggleSearch() {
+    this.setState({ searchShowing: !this.state.searchShowing });
+    if (this.state.searchShowing) {
+      this.componentDidMount();
     }
+  }
 
-    toggleSearch() {
-        this.setState({searchShowing:!this.state.searchShowing});
-        if(this.state.searchShowing) {
-            this.componentDidMount();
-        }
-    }
-    
-    componentDidMount() {
-        this.props.getPlaylistTracks(this.props.playlistId);
-    }
-    
-    render() {
-        return (
-            <div>
-                <Link to='/playlists'>Back we go bois</Link>
-                <div style={{textAlign:"right", marginRight : 10, marginBottom : 10}}><Button style={{backgroundColor: "#c030ed", borderColor : "#c030ed"}} onClick={this.toggleSearch}>{this.state.searchShowing ? 'Back' : 'Add track'}</Button></div>
-                {this.state.searchShowing ? <SearchPage/> : <Tracks title={this.props.activePlaylist.name} col1Name="Name" col2Name="Artist"/>}
-            </div>
-        )
-    }
+  componentDidMount() {
+    this.props.getPlaylistTracks(this.props.playlistId);
+  }
+
+  render() {
+    return (
+      <div>
+        <Link to="/playlists">Back we go bois</Link>
+        <div className="stickyContainer">
+        <h1 className="playlistTitle">{this.props.activePlaylist.name}</h1>
+          <Button  className="addButton"
+            style={{ backgroundColor: "#c030ed", borderColor: "#c030ed" }}
+            onClick={this.toggleSearch}
+          >
+            {this.state.searchShowing ? "Back" : "Add track"}
+          </Button>
+        </div>
+        {this.state.searchShowing ? (
+          <SearchPage />
+        ) : (
+          <Tracks
+            col1Name="Name"
+            col2Name="Artist"
+          />
+        )}
+      </div>
+    );
+  }
 }
 
 //State is entire state tree
 function mapStateToProps(state) {
-    return {
-        activePlaylist: state.playlists.active_playlist,
-        playlistId: window.location.pathname.split('/').pop(), //Grab playlist ID from URL
-        deviceId: state.webplayer.deviceId
-    };
+  return {
+    activePlaylist: state.playlists.active_playlist,
+    playlistId: window.location.pathname.split("/").pop(), //Grab playlist ID from URL
+    deviceId: state.webplayer.deviceId,
+  };
 }
 
 const mapDispatchToProps = {
-    getPlaylistTracks,
-}
+  getPlaylistTracks,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(TracksPage);


### PR DESCRIPTION
## Pull Request Information
Closes #42 

**What is the PR Type:** 
- feature


**Describe the added/fixed behaviour:**
The playlist name and the Add button are now sticky and remain on the top of the page upon scrolling. Works on mobile too

## Checklist
- [x] Pull request has suitable title and labels, adequately described and associated with a github issue
- [x] Branch name is descriptive
- [x] Branch builds and executes with no errors
- [ ] Test cases has been generated for the feature and test cases pass
- [ ] Updated relevant wiki/documentation

## Additional Information
![image](https://user-images.githubusercontent.com/42598015/81912888-53aba100-9623-11ea-9e05-1c5731d70182.png)

