### PR TITLE
songNameRolling

### DIFF
--- a/src/components/PlayerControls.js
+++ b/src/components/PlayerControls.js
@@ -4,6 +4,7 @@ import "./PlayerControls.scss";
 import * as spotify from "../SpotifyFunctions.js";
 import { FiSkipForward, FiSkipBack } from "react-icons/fi";
 
+
 class PlayerControls extends Component {
   togglePlay = () => {
     if (this.props.isPaused) {
@@ -19,6 +20,8 @@ class PlayerControls extends Component {
 
   skipBack = () => {
     spotify.skipToPrevious(this.props.deviceId);
+     spotify.seek(this.props.deviceId); /*not using this is fine, but if you click previous button when
+    palying the first song, it only pause and play, instead of go to the start of the song */
   };
 
   render() {
@@ -37,7 +40,8 @@ class PlayerControls extends Component {
           )}
         </div>
         <div className="trackInfo">
-          <p>{this.props.nowPlaying.name}</p>
+        <marquee  scrolldelay="200" >
+          <p>{this.props.nowPlaying.name}</p></marquee>
           <p>{this.props.nowPlaying.artists[0].name}</p>
         </div>
         <div onClick={this.togglePlay}>


### PR DESCRIPTION
## Pull Request Information
Closes # <!-- Insert issue number (required) -->

**What is the PR Type:** 
- bug fix
did a song name rolling, dont think singer name need to be rolling so didnt add it .
also I would like to use seek when go previous song, so when it;s playing the fist, it actually go the the back.
-->

**Describe the added/fixed behaviour:**
<!-- 
Describe the new/fixed behaviour this branch implements.
Include previous behaviour if PR is for a bug fix
Include screenshots if necessary
-->

## Checklist
<!-- Please check all items which apply from the following (Change "[ ]" to "[x]") -->
- [ ] Pull request has suitable title and labels, adequately described and associated with a github issue
- [ ] Branch name is descriptive
- [ ] Branch builds and executes with no errors
- [ ] Test cases has been generated for the feature and test cases pass
- [ ] Updated relevant wiki/documentation

## Additional Information
<!-- Please provide any additional information that may be necessary -->


<!-- Adapted from Uno Platform -->
